### PR TITLE
Update ci.yml to auto tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: ci
 
 on:
   push:
-    branches:
-      - 'master'
+    tags:
+      - 'v*'
+  pull_request:
 
 jobs:
   docker:
@@ -12,6 +13,11 @@ jobs:
       PLATFORMS: linux/amd64,linux/arm64/v8
     steps:
       - uses: actions/checkout@v2
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ secrets.CUSTOM_REGISTRY }}/pilgrim
       - name: Set up QEMU
         id: qemu
         uses: docker/setup-qemu-action@v1
@@ -20,6 +26,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 #      - name: Login to DockerHub
+#        if: github.event_name != 'pull_request'
 #        uses: docker/login-action@v1
 #        with:
 #          registry: ${{ secrets.CUSTOM_REGISTRY }}
@@ -29,9 +36,10 @@ jobs:
         id: docker_build
         uses: docker/build-push-action@v2
         with:
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           platforms: ${{ env.PLATFORMS }}
-          tags: ${{ secrets.CUSTOM_REGISTRY }}/pilgrim:latest
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
           cache-from: type=registry,ref=${{ secrets.CUSTOM_REGISTRY }}/pilgrim:latest
           cache-to: type=inline
       - name: Inspect


### PR DESCRIPTION
CI에서 도커 이미지를 만들때 git의 태그를 읽어와서 이미지의 태그로 사용한다.